### PR TITLE
fix client crash when started without internet connection

### DIFF
--- a/OfficeRibbonXEditor/Services/VersionChecker.cs
+++ b/OfficeRibbonXEditor/Services/VersionChecker.cs
@@ -24,11 +24,19 @@ namespace OfficeRibbonXEditor.Services
         public async Task<string> CheckVersionAsync(CancellationToken cancelToken = default(CancellationToken))
         {
             string latest;
-            using (var httpClient = new HttpClient())
+            try
             {
-                var uri = new Uri(CheckUrl);
-                var response = await httpClient.GetAsync(uri, cancelToken);
-                latest = await response.Content.ReadAsStringAsync();
+                using (var httpClient = new HttpClient())
+                {
+                    var uri = new Uri(CheckUrl);
+                    var response = await httpClient.GetAsync(uri, cancelToken);
+                    latest = await response.Content.ReadAsStringAsync();
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.Fail(e.Message); 
+                return null;
             }
 
             if (!Regex.IsMatch(latest, @"^\d+\.\d+\.\d+\.\d+$"))


### PR DESCRIPTION
There is a bug in the VersionChecker.cs

When starting the client without internet connection or it fails to make a successful request to CheckUrl: the client crashes.

Fixed by adding a try-catch arround the HttpClient-Request and returning null analogous to the other fail-handlings.