### PR TITLE
[codex] Add PowerShell CustomUI14 tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ bld/
 # NUNIT
 *.VisualState.xml
 TestResult.xml
+tests/UITests/Output/*.xlsm
 
 # Build Results of an ATL Project
 [Dd]ebugPS/

--- a/docs/CustomUI14-PowerShell.md
+++ b/docs/CustomUI14-PowerShell.md
@@ -1,0 +1,112 @@
+# CustomUI14 per PowerShell aktualisieren
+
+`scripts/Update-CustomUI14.ps1` aktualisiert den Office-2010-RibbonX-Part
+`/customUI/customUI14.xml` in einer `.xlsm`-Datei. Es wird nur Windows
+PowerShell 5.1 benoetigt; Office RibbonX Editor und .NET-SDK sind fuer die
+Ausfuehrung nicht erforderlich.
+
+## Aufruf
+
+```powershell
+.\scripts\Update-CustomUI14.ps1 `
+  -WorkbookPath "C:\Pfad\Datei.xlsm" `
+  -DefinitionPath "C:\Pfad\ribbon-def.txt"
+```
+
+Standardmaessig wird neben der Eingabedatei eine neue Datei mit dem Suffix
+`.ribbon.xlsm` geschrieben. Das Original bleibt unveraendert.
+
+Falls die lokale Execution Policy direkte Skriptaufrufe blockiert, kann der
+Aufruf explizit ueber PowerShell gestartet werden:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\Update-CustomUI14.ps1 `
+  -WorkbookPath "C:\Pfad\Datei.xlsm" `
+  -DefinitionPath "C:\Pfad\ribbon-def.txt"
+```
+
+```powershell
+.\scripts\Update-CustomUI14.ps1 `
+  -WorkbookPath "C:\Pfad\Datei.xlsm" `
+  -DefinitionPath "C:\Pfad\ribbon-def.txt" `
+  -OutputPath "C:\Pfad\Datei.mit-ribbon.xlsm"
+```
+
+Mit `-ForceInPlace` wird die angegebene Arbeitsmappe direkt geaendert:
+
+```powershell
+.\scripts\Update-CustomUI14.ps1 `
+  -WorkbookPath "C:\Pfad\Datei.xlsm" `
+  -DefinitionPath "C:\Pfad\ribbon-def.txt" `
+  -ForceInPlace
+```
+
+## Definitionsdatei
+
+Die Datei ist eine einfache, Semikolon-getrennte Textdatei. Leere Zeilen sind
+erlaubt. Metadaten stehen vor dem Tabellenkopf.
+
+```text
+#tab_id=tabCustom
+#tab_label=Meine Tools
+#group_id=grpMain
+#group_label=Aktionen
+#insert_after_mso=TabHome
+
+id;label;size;icon;onAction
+btnExport;Export;large;FileSaveAs;ExportMakro
+btnSync;Synchronisieren;normal;RefreshAll;SyncMakro
+```
+
+Pflicht-Metadaten:
+
+- `tab_id`
+- `tab_label`
+- `group_id`
+- `group_label`
+
+Optionale Metadaten:
+
+- `insert_after_mso`
+
+Tabellenfelder:
+
+- `id`: Pflicht, eindeutig innerhalb der Definitionsdatei
+- `label`: Pflicht
+- `size`: Pflicht, nur `normal` oder `large`
+- `icon`: Pflicht, wird als `imageMso` geschrieben
+- `onAction`: Pflicht, Name des VBA-Callbacks
+
+Eine durchsuchbare Uebersicht aktueller Microsoft-365-`imageMso`-Namen liegt
+in `docs/OfficeImageMso-Catalog.csv`; Hinweise zum Aktualisieren stehen in
+`docs/OfficeImageMso-Catalog.md`.
+
+Doppelte `id`-Werte sind ein Fehler. Das Skript bricht ab, bevor die Datei
+geaendert wird.
+
+## Verhalten
+
+- Fehlt `/customUI/customUI14.xml`, wird der Part erstellt.
+- Eine Package-Relationship auf `customUI/customUI14.xml` wird bei Bedarf
+  erstellt.
+- Ein vorhandenes `/customUI/customUI.xml` bleibt unangetastet.
+- Existiert der konfigurierte Tab, die Gruppe oder ein Button bereits, werden
+  die Attribute aktualisiert.
+- Makros werden nicht erzeugt. `onAction` referenziert nur vorhandene oder
+  spaeter anzulegende VBA-Prozeduren.
+
+## Pruefen
+
+Der optionale Helfer zeigt den vorhandenen CustomUI14-Part und die Buttons an:
+
+```powershell
+.\scripts\Test-InspectCustomUI14.ps1 -WorkbookPath "C:\Pfad\Datei.ribbon.xlsm"
+```
+
+## Typische Fehler
+
+Wenn die Datei in Excel geoeffnet ist, kann das Paket nicht geschrieben werden.
+Excel schliessen und den Befehl erneut ausfuehren.
+
+Bei ungueltiger Definition meldet das Skript die Zeilennummer, zum Beispiel bei
+fehlenden Feldern, `size=big` oder doppelten IDs.

--- a/docs/OfficeImageMso-Catalog.md
+++ b/docs/OfficeImageMso-Catalog.md
@@ -1,0 +1,50 @@
+# Office imageMso catalog
+
+Die Datei `OfficeImageMso-Catalog.csv` enthaelt eine durchsuchbare Liste von
+Office Fluent UI Control Identifiers, die als `imageMso`-Namen fuer RibbonX
+hilfreich sind.
+
+Quelle ist Microsofts offizielles GitHub-Repository:
+
+https://github.com/OfficeDev/office-fluent-ui-command-identifiers
+
+Verwendet wird standardmaessig:
+
+`Microsoft 365/Current Channel`
+
+## Spalten
+
+- `ImageMso`: Name fuer `imageMso="..."`
+- `Application`: Office-Anwendung oder Outlook-Kontextdatei aus der Quelle
+- `ControlType`: Typ des Controls, z. B. `button`, `toggleButton`, `menu`
+- `TabSet`, `Tab`, `GroupOrContextMenu`: Ribbon- oder Kontextmenue-Position
+- `ParentControl`, `SecondaryParentControl`: uebergeordnete Controls, falls vorhanden
+- `PolicyId`: Policy-ID aus Microsofts Liste
+- `Description`: kompakter Suchtext aus Anwendung, Typ und Ribbon-Kontext
+
+Die Microsoft-Dateien enthalten keine freien Icon-Beschreibungen oder
+Tooltip-Texte. Die Beschreibung in der CSV ist deshalb aus den vorhandenen
+Kontextspalten zusammengesetzt.
+
+## Aktualisieren
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\Update-OfficeImageMsoCatalog.ps1
+```
+
+Optional kann ein anderer Microsoft-365-Kanal angegeben werden:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\Update-OfficeImageMsoCatalog.ps1 `
+  -ChannelPath "Microsoft 365/Semi-Annual Enterprise Channel"
+```
+
+## Suchen
+
+Die CSV laesst sich in Excel, VS Code oder per PowerShell filtern:
+
+```powershell
+Import-Csv .\docs\OfficeImageMso-Catalog.csv |
+  Where-Object { $_.ImageMso -like '*Save*' -or $_.Description -like '*Clipboard*' } |
+  Select-Object -First 20 ImageMso,Application,ControlType,Description
+```

--- a/scripts/Test-InspectCustomUI14.ps1
+++ b/scripts/Test-InspectCustomUI14.ps1
@@ -1,0 +1,89 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $WorkbookPath
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+$CustomUi14Namespace = 'http://schemas.microsoft.com/office/2009/07/customui'
+$CustomUiRelationshipType = 'http://schemas.microsoft.com/office/2007/relationships/ui/extensibility'
+
+function Get-CustomUi14Relationship {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.IO.Packaging.Package] $Package
+    )
+
+    foreach ($relationship in $Package.GetRelationshipsByType($CustomUiRelationshipType)) {
+        if ($relationship.TargetMode -ne [System.IO.Packaging.TargetMode]::Internal) {
+            continue
+        }
+
+        if ($relationship.TargetUri.OriginalString.TrimStart('/') -ieq 'customUI/customUI14.xml') {
+            return $relationship
+        }
+    }
+
+    return $null
+}
+
+try {
+    if (-not (Test-Path -LiteralPath $WorkbookPath -PathType Leaf)) {
+        throw "WorkbookPath wurde nicht gefunden: $WorkbookPath"
+    }
+
+    Add-Type -AssemblyName WindowsBase
+
+    $resolvedWorkbookPath = (Resolve-Path -LiteralPath $WorkbookPath).ProviderPath
+    $partUri = New-Object System.Uri('/customUI/customUI14.xml', [System.UriKind]::Relative)
+    $package = $null
+
+    try {
+        $package = [System.IO.Packaging.Package]::Open($resolvedWorkbookPath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read)
+        $relationship = Get-CustomUi14Relationship -Package $package
+        if ($null -eq $relationship -or -not $package.PartExists($partUri)) {
+            Write-Host "customUI14.xml: nicht vorhanden"
+            exit 2
+        }
+
+        $part = $package.GetPart($partUri)
+        $document = New-Object System.Xml.XmlDocument
+        $stream = $part.GetStream([System.IO.FileMode]::Open, [System.IO.FileAccess]::Read)
+        try {
+            $document.Load($stream)
+        } finally {
+            $stream.Dispose()
+        }
+
+        if ($document.DocumentElement.NamespaceURI -ne $CustomUi14Namespace) {
+            throw "customUI14.xml verwendet nicht den erwarteten Namespace $CustomUi14Namespace."
+        }
+
+        $namespaceManager = New-Object System.Xml.XmlNamespaceManager($document.NameTable)
+        $namespaceManager.AddNamespace('ui', $CustomUi14Namespace)
+        $buttons = $document.SelectNodes('/ui:customUI/ui:ribbon/ui:tabs/ui:tab/ui:group/ui:button', $namespaceManager)
+
+        Write-Host "customUI14.xml: vorhanden"
+        Write-Host "Namespace: $($document.DocumentElement.NamespaceURI)"
+        foreach ($button in $buttons) {
+            [pscustomobject] @{
+                TabId = $button.ParentNode.ParentNode.GetAttribute('id')
+                GroupId = $button.ParentNode.GetAttribute('id')
+                Id = $button.GetAttribute('id')
+                Label = $button.GetAttribute('label')
+                Size = $button.GetAttribute('size')
+                ImageMso = $button.GetAttribute('imageMso')
+                OnAction = $button.GetAttribute('onAction')
+            }
+        }
+    } finally {
+        if ($null -ne $package) {
+            $package.Close()
+        }
+    }
+} catch {
+    [Console]::Error.WriteLine("ERROR: $($_.Exception.Message)")
+    exit 1
+}

--- a/scripts/Update-CustomUI14.ps1
+++ b/scripts/Update-CustomUI14.ps1
@@ -1,0 +1,485 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $WorkbookPath,
+
+    [Parameter(Mandatory = $true)]
+    [string] $DefinitionPath,
+
+    [string] $OutputPath,
+
+    [switch] $ForceInPlace
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+$CustomUi14Namespace = 'http://schemas.microsoft.com/office/2009/07/customui'
+$CustomUiRelationshipType = 'http://schemas.microsoft.com/office/2007/relationships/ui/extensibility'
+
+function Resolve-RequiredFile {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Path,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Name
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "$Name wurde nicht gefunden: $Path"
+    }
+
+    return (Resolve-Path -LiteralPath $Path).ProviderPath
+}
+
+function Assert-XlsmPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Path,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Name
+    )
+
+    if ([System.IO.Path]::GetExtension($Path) -ine '.xlsm') {
+        throw "$Name muss eine .xlsm-Datei sein: $Path"
+    }
+}
+
+function Split-DefinitionLine {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Line,
+
+        [Parameter(Mandatory = $true)]
+        [int] $LineNumber
+    )
+
+    $fields = $Line.Split(';')
+    for ($i = 0; $i -lt $fields.Count; $i++) {
+        $fields[$i] = $fields[$i].Trim()
+    }
+
+    if ($fields.Count -ne 5) {
+        throw "Definition Zeile ${LineNumber}: Erwartet 5 ;-getrennte Felder, gefunden $($fields.Count)."
+    }
+
+    return $fields
+}
+
+function Read-RibbonDefinition {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Path
+    )
+
+    $requiredHeaders = @('tab_id', 'tab_label', 'group_id', 'group_label')
+    $metadata = @{}
+    $buttons = @()
+    $seenIds = @{}
+    $tableStarted = $false
+    $expectedHeader = @('id', 'label', 'size', 'icon', 'onAction')
+    $lines = Get-Content -LiteralPath $Path
+
+    for ($lineIndex = 0; $lineIndex -lt $lines.Count; $lineIndex++) {
+        $lineNumber = $lineIndex + 1
+        $line = $lines[$lineIndex].Trim()
+
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        if ($line.StartsWith('#')) {
+            if ($tableStarted) {
+                continue
+            }
+
+            $metadataMatch = [regex]::Match($line, '^#(?<key>[^=]+)=(?<value>.*)$')
+            if (-not $metadataMatch.Success) {
+                continue
+            }
+
+            $key = $metadataMatch.Groups['key'].Value.Trim()
+            $value = $metadataMatch.Groups['value'].Value.Trim()
+            if ([string]::IsNullOrWhiteSpace($key) -or [string]::IsNullOrWhiteSpace($value)) {
+                throw "Definition Zeile ${lineNumber}: Ungueltige Metadatenzeile."
+            }
+
+            $metadata[$key] = $value
+            continue
+        }
+
+        $fields = Split-DefinitionLine -Line $line -LineNumber $lineNumber
+
+        if (-not $tableStarted) {
+            for ($i = 0; $i -lt $expectedHeader.Count; $i++) {
+                if ($fields[$i] -cne $expectedHeader[$i]) {
+                    throw "Definition Zeile ${lineNumber}: Erwarteter Tabellenkopf ist 'id;label;size;icon;onAction'."
+                }
+            }
+
+            $tableStarted = $true
+            continue
+        }
+
+        $id = $fields[0]
+        $label = $fields[1]
+        $size = $fields[2]
+        $icon = $fields[3]
+        $onAction = $fields[4]
+
+        if ([string]::IsNullOrWhiteSpace($id)) {
+            throw "Definition Zeile ${lineNumber}: id ist Pflicht."
+        }
+
+        if ([string]::IsNullOrWhiteSpace($label)) {
+            throw "Definition Zeile ${lineNumber}: label ist Pflicht."
+        }
+
+        if ($size -cne 'normal' -and $size -cne 'large') {
+            throw "Definition Zeile ${lineNumber}: size muss 'normal' oder 'large' sein."
+        }
+
+        if ([string]::IsNullOrWhiteSpace($icon)) {
+            throw "Definition Zeile ${lineNumber}: icon ist Pflicht."
+        }
+
+        if ([string]::IsNullOrWhiteSpace($onAction)) {
+            throw "Definition Zeile ${lineNumber}: onAction ist Pflicht."
+        }
+
+        if ($seenIds.ContainsKey($id)) {
+            throw "Definition Zeile ${lineNumber}: Doppelte id '$id' (bereits in Zeile $($seenIds[$id]))."
+        }
+
+        $seenIds[$id] = $lineNumber
+        $buttons += [pscustomobject] @{
+            Id = $id
+            Label = $label
+            Size = $size
+            Icon = $icon
+            OnAction = $onAction
+            LineNumber = $lineNumber
+        }
+    }
+
+    if (-not $tableStarted) {
+        throw "Definition enthaelt keinen Tabellenkopf 'id;label;size;icon;onAction'."
+    }
+
+    foreach ($headerName in $requiredHeaders) {
+        if (-not $metadata.ContainsKey($headerName) -or [string]::IsNullOrWhiteSpace($metadata[$headerName])) {
+            throw "Definition fehlt Pflicht-Metadatum #$headerName=..."
+        }
+    }
+
+    return [pscustomobject] @{
+        TabId = $metadata['tab_id']
+        TabLabel = $metadata['tab_label']
+        GroupId = $metadata['group_id']
+        GroupLabel = $metadata['group_label']
+        InsertAfterMso = $metadata['insert_after_mso']
+        Buttons = $buttons
+    }
+}
+
+function Get-DirectElement {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Xml.XmlNode] $Parent,
+
+        [Parameter(Mandatory = $true)]
+        [string] $LocalName,
+
+        [string] $AttributeName,
+
+        [string] $AttributeValue
+    )
+
+    foreach ($child in $Parent.ChildNodes) {
+        if ($child.NodeType -ne [System.Xml.XmlNodeType]::Element) {
+            continue
+        }
+
+        if ($child.LocalName -ne $LocalName -or $child.NamespaceURI -ne $CustomUi14Namespace) {
+            continue
+        }
+
+        if ([string]::IsNullOrEmpty($AttributeName)) {
+            return $child
+        }
+
+        if ($child.GetAttribute($AttributeName) -ceq $AttributeValue) {
+            return $child
+        }
+    }
+
+    return $null
+}
+
+function New-CustomUiElement {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Xml.XmlDocument] $Document,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Name
+    )
+
+    return $Document.CreateElement($Name, $CustomUi14Namespace)
+}
+
+function Get-OrCreateChildElement {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Xml.XmlNode] $Parent,
+
+        [Parameter(Mandatory = $true)]
+        [System.Xml.XmlDocument] $Document,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Name
+    )
+
+    $child = Get-DirectElement -Parent $Parent -LocalName $Name
+    if ($null -ne $child) {
+        return $child
+    }
+
+    $child = New-CustomUiElement -Document $Document -Name $Name
+    [void] $Parent.AppendChild($child)
+    return $child
+}
+
+function Get-CustomUi14Relationship {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.IO.Packaging.Package] $Package
+    )
+
+    foreach ($relationship in $Package.GetRelationshipsByType($CustomUiRelationshipType)) {
+        if ($relationship.TargetMode -ne [System.IO.Packaging.TargetMode]::Internal) {
+            continue
+        }
+
+        $target = $relationship.TargetUri.OriginalString.TrimStart('/')
+        if ($target -ieq 'customUI/customUI14.xml') {
+            return $relationship
+        }
+    }
+
+    return $null
+}
+
+function Read-CustomUiDocument {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.IO.Packaging.PackagePart] $Part
+    )
+
+    $document = New-Object System.Xml.XmlDocument
+    $document.PreserveWhitespace = $false
+
+    $stream = $null
+    try {
+        $stream = $Part.GetStream([System.IO.FileMode]::Open, [System.IO.FileAccess]::Read)
+        if ($stream.Length -eq 0) {
+            $document.LoadXml('<customUI xmlns="' + $CustomUi14Namespace + '"><ribbon><tabs /></ribbon></customUI>')
+        } else {
+            $document.Load($stream)
+        }
+    } finally {
+        if ($null -ne $stream) {
+            $stream.Dispose()
+        }
+    }
+
+    if ($document.DocumentElement.LocalName -ne 'customUI' -or $document.DocumentElement.NamespaceURI -ne $CustomUi14Namespace) {
+        throw "Vorhandenes customUI14.xml verwendet nicht den erwarteten Namespace $CustomUi14Namespace."
+    }
+
+    return $document
+}
+
+function Save-CustomUiDocument {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Xml.XmlDocument] $Document,
+
+        [Parameter(Mandatory = $true)]
+        [System.IO.Packaging.PackagePart] $Part
+    )
+
+    $settings = New-Object System.Xml.XmlWriterSettings
+    $settings.Indent = $true
+    $settings.Encoding = New-Object System.Text.UTF8Encoding($false)
+
+    $stream = $null
+    $writer = $null
+    try {
+        $stream = $Part.GetStream([System.IO.FileMode]::Create, [System.IO.FileAccess]::Write)
+        $writer = [System.Xml.XmlWriter]::Create($stream, $settings)
+        $Document.Save($writer)
+    } finally {
+        if ($null -ne $writer) {
+            $writer.Dispose()
+        } elseif ($null -ne $stream) {
+            $stream.Dispose()
+        }
+    }
+}
+
+function Update-CustomUi14 {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $TargetPath,
+
+        [Parameter(Mandatory = $true)]
+        [pscustomobject] $Definition
+    )
+
+    Add-Type -AssemblyName WindowsBase
+
+    $partUri = New-Object System.Uri('/customUI/customUI14.xml', [System.UriKind]::Relative)
+    $relationshipUri = New-Object System.Uri('customUI/customUI14.xml', [System.UriKind]::Relative)
+    $package = $null
+    $createdPart = $false
+    $createdTabs = 0
+    $createdGroups = 0
+    $createdButtons = 0
+    $updatedButtons = 0
+
+    try {
+        $package = [System.IO.Packaging.Package]::Open($TargetPath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite)
+        $relationship = Get-CustomUi14Relationship -Package $package
+        if ($null -eq $relationship) {
+            [void] $package.CreateRelationship($relationshipUri, [System.IO.Packaging.TargetMode]::Internal, $CustomUiRelationshipType)
+            Write-Verbose "Package-Relationship fuer customUI14.xml erstellt."
+        }
+
+        if ($package.PartExists($partUri)) {
+            $part = $package.GetPart($partUri)
+        } else {
+            $part = $package.CreatePart($partUri, 'application/xml', [System.IO.Packaging.CompressionOption]::Maximum)
+            $createdPart = $true
+            Write-Verbose "Part /customUI/customUI14.xml erstellt."
+        }
+
+        $document = Read-CustomUiDocument -Part $part
+        $customUi = $document.DocumentElement
+        $ribbon = Get-OrCreateChildElement -Parent $customUi -Document $document -Name 'ribbon'
+        $tabs = Get-OrCreateChildElement -Parent $ribbon -Document $document -Name 'tabs'
+
+        $tab = Get-DirectElement -Parent $tabs -LocalName 'tab' -AttributeName 'id' -AttributeValue $Definition.TabId
+        if ($null -eq $tab) {
+            $tab = New-CustomUiElement -Document $document -Name 'tab'
+            [void] $tabs.AppendChild($tab)
+            $createdTabs++
+        }
+
+        $tab.SetAttribute('id', $Definition.TabId)
+        $tab.SetAttribute('label', $Definition.TabLabel)
+        if (-not [string]::IsNullOrWhiteSpace($Definition.InsertAfterMso)) {
+            $tab.SetAttribute('insertAfterMso', $Definition.InsertAfterMso)
+        }
+
+        $group = Get-DirectElement -Parent $tab -LocalName 'group' -AttributeName 'id' -AttributeValue $Definition.GroupId
+        if ($null -eq $group) {
+            $group = New-CustomUiElement -Document $document -Name 'group'
+            [void] $tab.AppendChild($group)
+            $createdGroups++
+        }
+
+        $group.SetAttribute('id', $Definition.GroupId)
+        $group.SetAttribute('label', $Definition.GroupLabel)
+
+        foreach ($buttonDefinition in $Definition.Buttons) {
+            $button = Get-DirectElement -Parent $group -LocalName 'button' -AttributeName 'id' -AttributeValue $buttonDefinition.Id
+            if ($null -eq $button) {
+                $button = New-CustomUiElement -Document $document -Name 'button'
+                [void] $group.AppendChild($button)
+                $createdButtons++
+            } else {
+                $updatedButtons++
+            }
+
+            $button.SetAttribute('id', $buttonDefinition.Id)
+            $button.SetAttribute('label', $buttonDefinition.Label)
+            $button.SetAttribute('size', $buttonDefinition.Size)
+            $button.SetAttribute('imageMso', $buttonDefinition.Icon)
+            $button.SetAttribute('onAction', $buttonDefinition.OnAction)
+        }
+
+        Save-CustomUiDocument -Document $document -Part $part
+        $package.Flush()
+    } finally {
+        if ($null -ne $package) {
+            $package.Close()
+        }
+    }
+
+    return [pscustomobject] @{
+        CreatedPart = $createdPart
+        CreatedTabs = $createdTabs
+        CreatedGroups = $createdGroups
+        CreatedButtons = $createdButtons
+        UpdatedButtons = $updatedButtons
+        OutputPath = $TargetPath
+    }
+}
+
+try {
+    $resolvedWorkbookPath = Resolve-RequiredFile -Path $WorkbookPath -Name 'WorkbookPath'
+    $resolvedDefinitionPath = Resolve-RequiredFile -Path $DefinitionPath -Name 'DefinitionPath'
+    Assert-XlsmPath -Path $resolvedWorkbookPath -Name 'WorkbookPath'
+
+    if ($ForceInPlace -and -not [string]::IsNullOrWhiteSpace($OutputPath)) {
+        throw "OutputPath darf nicht zusammen mit ForceInPlace verwendet werden."
+    }
+
+    if ($ForceInPlace) {
+        $targetPath = $resolvedWorkbookPath
+    } else {
+        if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+            $sourceDirectory = [System.IO.Path]::GetDirectoryName($resolvedWorkbookPath)
+            $sourceBaseName = [System.IO.Path]::GetFileNameWithoutExtension($resolvedWorkbookPath)
+            $sourceExtension = [System.IO.Path]::GetExtension($resolvedWorkbookPath)
+            $targetPath = Join-Path $sourceDirectory "$sourceBaseName.ribbon$sourceExtension"
+        } else {
+            $targetPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($OutputPath)
+        }
+
+        Assert-XlsmPath -Path $targetPath -Name 'OutputPath'
+
+        if ([string]::Equals($resolvedWorkbookPath, $targetPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "OutputPath entspricht WorkbookPath. Verwende ForceInPlace, wenn die Originaldatei ueberschrieben werden soll."
+        }
+
+        $targetDirectory = [System.IO.Path]::GetDirectoryName($targetPath)
+        if (-not (Test-Path -LiteralPath $targetDirectory -PathType Container)) {
+            throw "OutputPath-Verzeichnis wurde nicht gefunden: $targetDirectory"
+        }
+
+        Copy-Item -LiteralPath $resolvedWorkbookPath -Destination $targetPath -Force
+    }
+
+    $definition = Read-RibbonDefinition -Path $resolvedDefinitionPath
+    $result = Update-CustomUi14 -TargetPath $targetPath -Definition $definition
+
+    Write-Host "CustomUI14 wurde aktualisiert."
+    Write-Host "CreatedTabs: $($result.CreatedTabs)"
+    Write-Host "CreatedGroups: $($result.CreatedGroups)"
+    Write-Host "CreatedButtons: $($result.CreatedButtons)"
+    Write-Host "UpdatedButtons: $($result.UpdatedButtons)"
+    Write-Host "OutputPath: $($result.OutputPath)"
+    exit 0
+} catch {
+    $message = $_.Exception.Message
+    if ($_.Exception -is [System.IO.IOException] -or $_.Exception.InnerException -is [System.IO.IOException]) {
+        $message = "$message Bitte pruefen, ob die Datei in Excel geoeffnet ist, und Excel schliessen."
+    }
+
+    [Console]::Error.WriteLine("ERROR: $message")
+    exit 1
+}

--- a/scripts/Update-OfficeImageMsoCatalog.ps1
+++ b/scripts/Update-OfficeImageMsoCatalog.ps1
@@ -1,0 +1,356 @@
+[CmdletBinding()]
+param(
+    [string] $OutputPath,
+
+    [string] $ChannelPath = 'Microsoft 365/Current Channel'
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+$RepositoryApiRoot = 'https://api.github.com/repos/OfficeDev/office-fluent-ui-command-identifiers'
+
+function Get-ColumnIndex {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $CellReference
+    )
+
+    $letters = ([regex]::Match($CellReference, '^[A-Z]+')).Value
+    $index = 0
+    foreach ($character in $letters.ToCharArray()) {
+        $index = ($index * 26) + ([int][char]$character - [int][char]'A' + 1)
+    }
+
+    return $index
+}
+
+function Get-EntryText {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.IO.Compression.ZipArchive] $Archive,
+
+        [Parameter(Mandatory = $true)]
+        [string] $EntryName
+    )
+
+    $entry = $Archive.GetEntry($EntryName)
+    if ($null -eq $entry) {
+        return $null
+    }
+
+    $stream = $null
+    $reader = $null
+    try {
+        $stream = $entry.Open()
+        $reader = New-Object System.IO.StreamReader($stream)
+        return $reader.ReadToEnd()
+    } finally {
+        if ($null -ne $reader) {
+            $reader.Dispose()
+        } elseif ($null -ne $stream) {
+            $stream.Dispose()
+        }
+    }
+}
+
+function Get-SharedStrings {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.IO.Compression.ZipArchive] $Archive
+    )
+
+    $content = Get-EntryText -Archive $Archive -EntryName 'xl/sharedStrings.xml'
+    if ([string]::IsNullOrWhiteSpace($content)) {
+        return @()
+    }
+
+    $document = New-Object System.Xml.XmlDocument
+    $document.LoadXml($content)
+
+    $namespaceManager = New-Object System.Xml.XmlNamespaceManager($document.NameTable)
+    $namespaceManager.AddNamespace('x', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main')
+
+    $strings = New-Object System.Collections.Generic.List[string]
+    foreach ($item in $document.SelectNodes('/x:sst/x:si', $namespaceManager)) {
+        $textParts = foreach ($textNode in $item.SelectNodes('.//x:t', $namespaceManager)) {
+            $textNode.InnerText
+        }
+
+        $strings.Add(($textParts -join ''))
+    }
+
+    return $strings.ToArray()
+}
+
+function Get-CellValue {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Xml.XmlElement] $Cell,
+
+        [Parameter(Mandatory = $true)]
+        [string[]] $SharedStrings,
+
+        [Parameter(Mandatory = $true)]
+        [System.Xml.XmlNamespaceManager] $NamespaceManager
+    )
+
+    $type = $Cell.GetAttribute('t')
+    if ($type -eq 'inlineStr') {
+        return (($Cell.SelectNodes('.//x:t', $NamespaceManager) | ForEach-Object { $_.InnerText }) -join '')
+    }
+
+    $valueNode = $Cell.SelectSingleNode('x:v', $NamespaceManager)
+    if ($null -eq $valueNode) {
+        return ''
+    }
+
+    if ($type -eq 's') {
+        $index = [int] $valueNode.InnerText
+        if ($index -ge 0 -and $index -lt $SharedStrings.Count) {
+            return $SharedStrings[$index]
+        }
+
+        return ''
+    }
+
+    return $valueNode.InnerText
+}
+
+function Read-FirstWorksheet {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $WorkbookPath
+    )
+
+    Add-Type -AssemblyName System.IO.Compression
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    $archive = $null
+    try {
+        $archive = [System.IO.Compression.ZipFile]::OpenRead($WorkbookPath)
+        $sharedStrings = Get-SharedStrings -Archive $archive
+        $worksheetEntry = $archive.Entries |
+            Where-Object { $_.FullName -like 'xl/worksheets/*.xml' } |
+            Sort-Object FullName |
+            Select-Object -First 1
+
+        if ($null -eq $worksheetEntry) {
+            throw "Workbook contains no worksheets: $WorkbookPath"
+        }
+
+        $worksheetXml = Get-EntryText -Archive $archive -EntryName $worksheetEntry.FullName
+        $document = New-Object System.Xml.XmlDocument
+        $document.LoadXml($worksheetXml)
+
+        $namespaceManager = New-Object System.Xml.XmlNamespaceManager($document.NameTable)
+        $namespaceManager.AddNamespace('x', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main')
+
+        $rows = New-Object System.Collections.Generic.List[object[]]
+        foreach ($row in $document.SelectNodes('/x:worksheet/x:sheetData/x:row', $namespaceManager)) {
+            $valuesByColumn = @{}
+            $maxColumn = 0
+            foreach ($cell in $row.SelectNodes('x:c', $namespaceManager)) {
+                $columnIndex = Get-ColumnIndex -CellReference $cell.GetAttribute('r')
+                $valuesByColumn[$columnIndex] = Get-CellValue -Cell $cell -SharedStrings $sharedStrings -NamespaceManager $namespaceManager
+                if ($columnIndex -gt $maxColumn) {
+                    $maxColumn = $columnIndex
+                }
+            }
+
+            $values = for ($i = 1; $i -le $maxColumn; $i++) {
+                if ($valuesByColumn.ContainsKey($i)) {
+                    $valuesByColumn[$i]
+                } else {
+                    ''
+                }
+            }
+
+            $rows.Add([object[]] $values)
+        }
+
+        return $rows.ToArray()
+    } finally {
+        if ($null -ne $archive) {
+            $archive.Dispose()
+        }
+    }
+}
+
+function Get-Value {
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable] $Row,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Name
+    )
+
+    if ($Row.ContainsKey($Name)) {
+        return ($Row[$Name]).Trim()
+    }
+
+    return ''
+}
+
+function Get-AppName {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $FileName
+    )
+
+    $name = [System.IO.Path]::GetFileNameWithoutExtension($FileName)
+    return ($name -replace 'controls$', '')
+}
+
+function Join-Description {
+    param(
+        [string] $Application,
+        [string] $ControlType,
+        [string] $Tab,
+        [string] $GroupOrContextMenu,
+        [string] $ParentControl,
+        [string] $SecondaryParentControl
+    )
+
+    $parts = New-Object System.Collections.Generic.List[string]
+    if (-not [string]::IsNullOrWhiteSpace($Application)) {
+        $parts.Add("App: $Application")
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($ControlType)) {
+        $parts.Add("Typ: $ControlType")
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($Tab)) {
+        $parts.Add("Tab: $Tab")
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($GroupOrContextMenu)) {
+        $parts.Add("Gruppe/Kontext: $GroupOrContextMenu")
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($ParentControl)) {
+        $parts.Add("Parent: $ParentControl")
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($SecondaryParentControl)) {
+        $parts.Add("Secondary Parent: $SecondaryParentControl")
+    }
+
+    return ($parts -join '; ')
+}
+
+function Convert-WorkbookToCatalogRows {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $WorkbookPath,
+
+        [Parameter(Mandatory = $true)]
+        [string] $SourceFile
+    )
+
+    $rows = Read-FirstWorksheet -WorkbookPath $WorkbookPath
+    if ($rows.Count -lt 2) {
+        return @()
+    }
+
+    $headers = @($rows[0])
+    $application = Get-AppName -FileName $SourceFile
+    $catalogRows = New-Object System.Collections.Generic.List[object]
+
+    for ($rowIndex = 1; $rowIndex -lt $rows.Count; $rowIndex++) {
+        $values = @($rows[$rowIndex])
+        $row = @{}
+        for ($columnIndex = 0; $columnIndex -lt $headers.Count; $columnIndex++) {
+            if ($columnIndex -lt $values.Count) {
+                $row[$headers[$columnIndex]] = [string] $values[$columnIndex]
+            } else {
+                $row[$headers[$columnIndex]] = ''
+            }
+        }
+
+        $controlName = Get-Value -Row $row -Name 'Control Name'
+        if ([string]::IsNullOrWhiteSpace($controlName)) {
+            continue
+        }
+
+        $controlType = Get-Value -Row $row -Name 'Control Type'
+        $tabSet = Get-Value -Row $row -Name 'Tab Set'
+        $tab = Get-Value -Row $row -Name 'Tab'
+        $groupOrContextMenu = Get-Value -Row $row -Name 'Group/Context Menu Name'
+        $parentControl = Get-Value -Row $row -Name 'Parent Control'
+        $secondaryParentControl = Get-Value -Row $row -Name 'Secondary Parent Control'
+        $policyId = Get-Value -Row $row -Name 'Policy ID'
+
+        $catalogRows.Add([pscustomobject] @{
+            ImageMso = $controlName
+            Application = $application
+            SourceFile = $SourceFile
+            ControlType = $controlType
+            TabSet = $tabSet
+            Tab = $tab
+            GroupOrContextMenu = $groupOrContextMenu
+            ParentControl = $parentControl
+            SecondaryParentControl = $secondaryParentControl
+            PolicyId = $policyId
+            Description = Join-Description `
+                -Application $application `
+                -ControlType $controlType `
+                -Tab $tab `
+                -GroupOrContextMenu $groupOrContextMenu `
+                -ParentControl $parentControl `
+                -SecondaryParentControl $secondaryParentControl
+        })
+    }
+
+    return $catalogRows.ToArray()
+}
+
+if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+    $OutputPath = Join-Path $PSScriptRoot '..\docs\OfficeImageMso-Catalog.csv'
+}
+
+$resolvedOutputPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($OutputPath)
+$outputDirectory = [System.IO.Path]::GetDirectoryName($resolvedOutputPath)
+if (-not (Test-Path -LiteralPath $outputDirectory -PathType Container)) {
+    New-Item -ItemType Directory -Path $outputDirectory | Out-Null
+}
+
+$encodedChannelPath = [System.Uri]::EscapeDataString($ChannelPath).Replace('%2F', '/')
+$contentsUrl = "$RepositoryApiRoot/contents/$encodedChannelPath`?ref=main"
+$items = Invoke-RestMethod -Uri $contentsUrl -Headers @{ 'User-Agent' = 'OfficeRibbonXEditor-CatalogUpdater' }
+$workbookItems = @($items | Where-Object { $_.type -eq 'file' -and $_.name -like '*controls.xlsx' } | Sort-Object name)
+
+if ($workbookItems.Count -eq 0) {
+    throw "No *controls.xlsx files found at $ChannelPath."
+}
+
+$downloadDirectory = Join-Path ([System.IO.Path]::GetTempPath()) ("OfficeImageMsoCatalog-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $downloadDirectory | Out-Null
+
+$catalogRows = New-Object System.Collections.Generic.List[object]
+try {
+    foreach ($item in $workbookItems) {
+        $localWorkbookPath = Join-Path $downloadDirectory $item.name
+        Write-Verbose "Downloading $($item.download_url)"
+        Invoke-WebRequest -Uri $item.download_url -OutFile $localWorkbookPath
+
+        foreach ($catalogRow in (Convert-WorkbookToCatalogRows -WorkbookPath $localWorkbookPath -SourceFile $item.name)) {
+            $catalogRows.Add($catalogRow)
+        }
+    }
+} finally {
+    if (Test-Path -LiteralPath $downloadDirectory -PathType Container) {
+        Remove-Item -LiteralPath $downloadDirectory -Recurse -Force
+    }
+}
+
+$catalogRows |
+    Sort-Object ImageMso, Application, Tab, GroupOrContextMenu |
+    ConvertTo-Csv -NoTypeInformation |
+    Set-Content -LiteralPath $resolvedOutputPath -Encoding UTF8
+
+Write-Host "Office imageMso catalog written to $resolvedOutputPath"
+Write-Host "Rows: $($catalogRows.Count)"
+Write-Host "Source: https://github.com/OfficeDev/office-fluent-ui-command-identifiers/tree/main/$($ChannelPath.Replace(' ', '%20'))"

--- a/scripts/examples/ribbon-def.sample.txt
+++ b/scripts/examples/ribbon-def.sample.txt
@@ -1,0 +1,9 @@
+#tab_id=tabCustom
+#tab_label=Meine Tools
+#group_id=grpMain
+#group_label=Aktionen
+#insert_after_mso=TabHome
+
+id;label;size;icon;onAction
+btnExport;Export;large;FileSaveAs;ExportMakro
+btnSync;Synchronisieren;normal;RefreshAll;SyncMakro

--- a/tests/UITests/Main/CustomUi14PowerShellE2ETests.cs
+++ b/tests/UITests/Main/CustomUi14PowerShellE2ETests.cs
@@ -1,0 +1,562 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Xml.Linq;
+using FlaUI.Core;
+using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Definitions;
+using FlaUI.Core.Tools;
+using FlaUI.UIA3;
+using Microsoft.Win32;
+using NUnit.Framework;
+using OfficeRibbonXEditor.Common;
+using OfficeRibbonXEditor.UITests.Extensions;
+
+namespace OfficeRibbonXEditor.UITests.Main;
+
+[TestFixture]
+[SingleThreaded]
+[Apartment(ApartmentState.STA)]
+[SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "UI tests target Windows")]
+public sealed class CustomUi14PowerShellE2ETests
+{
+    private const string CustomUi14Namespace = "http://schemas.microsoft.com/office/2009/07/customui";
+    private const int XlOpenXmlWorkbookMacroEnabled = 52;
+    private const int MsoAutomationSecurityLow = 1;
+    private const int VbextCtStdModule = 1;
+
+    private string _testFolder = string.Empty;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _testFolder = Path.Combine(Path.GetTempPath(), "OfficeRibbonXEditorE2E", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_testFolder);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try
+        {
+            if (Directory.Exists(_testFolder))
+            {
+                Directory.Delete(_testFolder, true);
+            }
+        }
+        catch (IOException)
+        {
+            TestContext.WriteLine($"Could not delete test folder '{_testFolder}'.");
+        }
+        catch (UnauthorizedAccessException)
+        {
+            TestContext.WriteLine($"Could not delete test folder '{_testFolder}'.");
+        }
+    }
+
+    [Test]
+    public void RibbonXBaselineCanBeUpdatedByPowerShellToolAndVerifiedInExcel()
+    {
+        Assume.That(IsExcelInstalled(), Is.True, "Excel is required for this end-to-end UI test.");
+        Assume.That(IsVbaProjectAccessTrusted(), Is.True, "Excel Trust Center setting 'Trust access to the VBA project object model' is required.");
+
+        var repositoryRoot = FindRepositoryRoot();
+        var workbookPath = Path.Combine(_testFolder, "RibbonXBaseline.xlsm");
+        var updatedWorkbookPath = Path.Combine(_testFolder, "RibbonXUpdated.xlsm");
+        var definitionPath = Path.Combine(_testFolder, "update-def.txt");
+
+        CreateMacroEnabledWorkbook(workbookPath);
+        AddInitialRibbonXCustomUi(workbookPath);
+        AddOffice2007CustomUiRegressionPart(workbookPath);
+
+        AssertExcelRibbonButtons(
+            workbookPath,
+            tabLabel: "RX E2E",
+            groupLabel: "Baseline Actions",
+            expectedCallbacks: new Dictionary<string, string>
+            {
+                ["Export A"] = "ExportA",
+                ["Sync A"] = "SyncA",
+            });
+
+        var office2007CustomUiBefore = ReadCustomPart(workbookPath, XmlPart.RibbonX12);
+        WriteUpdateDefinition(definitionPath);
+
+        var firstUpdate = RunPowerShellTool(repositoryRoot, workbookPath, definitionPath, updatedWorkbookPath);
+        Assert.That(firstUpdate.ExitCode, Is.EqualTo(0), firstUpdate.AllOutput);
+        Assert.That(File.Exists(updatedWorkbookPath), Is.True, "The PowerShell tool did not create the requested output workbook.");
+        Assert.That(ReadCustomPart(workbookPath, XmlPart.RibbonX14), Does.Contain("Export A"), "The source workbook should stay unchanged when OutputPath is used.");
+        Assert.That(ReadCustomPart(updatedWorkbookPath, XmlPart.RibbonX12), Is.EqualTo(office2007CustomUiBefore), "The Office 2007 customUI.xml part must not be modified.");
+
+        AssertCustomUi14Buttons(
+            updatedWorkbookPath,
+            expectedTabLabel: "RX E2E Updated",
+            expectedGroupLabel: "Updated Actions",
+            expectedButtons: new[]
+            {
+                new ExpectedButton("btnExport", "Export B", "large", "FileSave", "ExportB"),
+                new ExpectedButton("btnSync", "Sync B", "normal", "Repeat", "SyncB"),
+                new ExpectedButton("btnClean", "Clean", "normal", "ClearFormatting", "CleanB"),
+            });
+
+        var secondUpdate = RunPowerShellTool(repositoryRoot, updatedWorkbookPath, definitionPath, updatedWorkbookPath, forceInPlace: true);
+        Assert.That(secondUpdate.ExitCode, Is.EqualTo(0), secondUpdate.AllOutput);
+        Assert.That(secondUpdate.AllOutput, Does.Contain("CreatedButtons: 0"));
+        Assert.That(secondUpdate.AllOutput, Does.Contain("UpdatedButtons: 3"));
+
+        AssertExcelRibbonButtons(
+            updatedWorkbookPath,
+            tabLabel: "RX E2E Updated",
+            groupLabel: "Updated Actions",
+            expectedCallbacks: new Dictionary<string, string>
+            {
+                ["Export B"] = "ExportB",
+                ["Sync B"] = "SyncB",
+                ["Clean"] = "CleanB",
+            });
+
+        PreserveWorkbookArtifact(repositoryRoot, updatedWorkbookPath);
+    }
+
+    [Test]
+    public void PowerShellToolReturnsErrorsForInvalidDefinitionsAndLockedWorkbooks()
+    {
+        Assume.That(IsExcelInstalled(), Is.True, "Excel is required to create the macro-enabled workbook fixture.");
+        Assume.That(IsVbaProjectAccessTrusted(), Is.True, "Excel Trust Center setting 'Trust access to the VBA project object model' is required.");
+
+        var repositoryRoot = FindRepositoryRoot();
+        var workbookPath = Path.Combine(_testFolder, "RibbonXBaseline.xlsm");
+        CreateMacroEnabledWorkbook(workbookPath);
+        AddInitialRibbonXCustomUi(workbookPath);
+
+        var invalidSizeDefinition = Path.Combine(_testFolder, "invalid-size-def.txt");
+        File.WriteAllText(
+            invalidSizeDefinition,
+            """
+            #tab_id=tabRxE2E
+            #tab_label=RX E2E
+            #group_id=grpBaseline
+            #group_label=Baseline Actions
+
+            id;label;size;icon;onAction
+            btnBad;Bad;big;FileSave;ExportB
+            """);
+
+        var invalidSizeResult = RunPowerShellTool(repositoryRoot, workbookPath, invalidSizeDefinition, Path.Combine(_testFolder, "InvalidSize.xlsm"));
+        Assert.That(invalidSizeResult.ExitCode, Is.Not.EqualTo(0));
+        Assert.That(invalidSizeResult.AllOutput, Does.Contain("size muss 'normal' oder 'large' sein"));
+
+        var duplicateIdDefinition = Path.Combine(_testFolder, "duplicate-id-def.txt");
+        File.WriteAllText(
+            duplicateIdDefinition,
+            """
+            #tab_id=tabRxE2E
+            #tab_label=RX E2E
+            #group_id=grpBaseline
+            #group_label=Baseline Actions
+
+            id;label;size;icon;onAction
+            btnSame;One;large;FileSave;ExportB
+            btnSame;Two;normal;Repeat;SyncB
+            """);
+
+        var duplicateIdResult = RunPowerShellTool(repositoryRoot, workbookPath, duplicateIdDefinition, Path.Combine(_testFolder, "DuplicateId.xlsm"));
+        Assert.That(duplicateIdResult.ExitCode, Is.Not.EqualTo(0));
+        Assert.That(duplicateIdResult.AllOutput, Does.Contain("Doppelte id 'btnSame'"));
+
+        var validDefinition = Path.Combine(_testFolder, "valid-def.txt");
+        WriteUpdateDefinition(validDefinition);
+        using var lockStream = new FileStream(workbookPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+        var lockedWorkbookResult = RunPowerShellTool(repositoryRoot, workbookPath, validDefinition, workbookPath, forceInPlace: true);
+        Assert.That(lockedWorkbookResult.ExitCode, Is.Not.EqualTo(0));
+        Assert.That(lockedWorkbookResult.AllOutput, Does.Contain("Excel"));
+    }
+
+    private static void CreateMacroEnabledWorkbook(string workbookPath)
+    {
+        using var session = ExcelSession.CreateVisible(visible: false);
+        dynamic excel = session.Excel;
+        excel.DisplayAlerts = false;
+
+        dynamic workbook = excel.Workbooks.Add();
+        session.Workbook = workbook;
+        workbook.Worksheets[1].Range("A1").Value2 = string.Empty;
+
+        dynamic module = workbook.VBProject.VBComponents.Add(VbextCtStdModule);
+        module.CodeModule.AddFromString(
+            """
+            Option Explicit
+
+            Public Sub ExportA(control)
+                ThisWorkbook.Worksheets(1).Range("A1").Value = "ExportA"
+            End Sub
+
+            Public Sub SyncA(control)
+                ThisWorkbook.Worksheets(1).Range("A1").Value = "SyncA"
+            End Sub
+
+            Public Sub ExportB(control)
+                ThisWorkbook.Worksheets(1).Range("A1").Value = "ExportB"
+            End Sub
+
+            Public Sub SyncB(control)
+                ThisWorkbook.Worksheets(1).Range("A1").Value = "SyncB"
+            End Sub
+
+            Public Sub CleanB(control)
+                ThisWorkbook.Worksheets(1).Range("A1").Value = "CleanB"
+            End Sub
+            """);
+
+        workbook.SaveAs(workbookPath, XlOpenXmlWorkbookMacroEnabled);
+    }
+
+    private static void AddInitialRibbonXCustomUi(string workbookPath)
+    {
+        using var document = new OfficeDocument(workbookPath);
+        var part = document.RetrieveCustomPart(XmlPart.RibbonX14) ?? document.CreateCustomPart(XmlPart.RibbonX14);
+        part.Save(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <customUI xmlns="http://schemas.microsoft.com/office/2009/07/customui">
+              <ribbon>
+                <tabs>
+                  <tab id="tabRxE2E" label="RX E2E" insertAfterMso="TabHome">
+                    <group id="grpBaseline" label="Baseline Actions">
+                      <button id="btnExport" label="Export A" size="large" imageMso="FileSaveAs" onAction="ExportA" />
+                      <button id="btnSync" label="Sync A" size="normal" imageMso="RefreshAll" onAction="SyncA" />
+                    </group>
+                  </tab>
+                </tabs>
+              </ribbon>
+            </customUI>
+            """);
+        document.Save();
+    }
+
+    private static void AddOffice2007CustomUiRegressionPart(string workbookPath)
+    {
+        using var document = new OfficeDocument(workbookPath);
+        var part = document.RetrieveCustomPart(XmlPart.RibbonX12) ?? document.CreateCustomPart(XmlPart.RibbonX12);
+        part.Save(
+            """
+            <?xml version="1.0" encoding="utf-8"?>
+            <customUI xmlns="http://schemas.microsoft.com/office/2006/01/customui">
+              <ribbon>
+                <tabs>
+                  <tab id="tabLegacy" label="Legacy UI" />
+                </tabs>
+              </ribbon>
+            </customUI>
+            """);
+        document.Save();
+    }
+
+    private static void WriteUpdateDefinition(string definitionPath)
+    {
+        File.WriteAllText(
+            definitionPath,
+            """
+            #tab_id=tabRxE2E
+            #tab_label=RX E2E Updated
+            #group_id=grpBaseline
+            #group_label=Updated Actions
+            #insert_after_mso=TabHome
+
+            id;label;size;icon;onAction
+            btnExport;Export B;large;FileSave;ExportB
+            btnSync;Sync B;normal;Repeat;SyncB
+            btnClean;Clean;normal;ClearFormatting;CleanB
+            """);
+    }
+
+    private static void AssertCustomUi14Buttons(string workbookPath, string expectedTabLabel, string expectedGroupLabel, IReadOnlyCollection<ExpectedButton> expectedButtons)
+    {
+        var customUi = ReadCustomPart(workbookPath, XmlPart.RibbonX14);
+        var document = XDocument.Parse(customUi);
+        var ns = XNamespace.Get(CustomUi14Namespace);
+        var tab = document.Root?.Element(ns + "ribbon")?.Element(ns + "tabs")?.Elements(ns + "tab").SingleOrDefault(x => (string?)x.Attribute("id") == "tabRxE2E");
+        Assert.That(tab, Is.Not.Null, "Expected CustomUI14 tab was not found.");
+        Assert.That((string?)tab!.Attribute("label"), Is.EqualTo(expectedTabLabel));
+
+        var group = tab.Elements(ns + "group").SingleOrDefault(x => (string?)x.Attribute("id") == "grpBaseline");
+        Assert.That(group, Is.Not.Null, "Expected CustomUI14 group was not found.");
+        Assert.That((string?)group!.Attribute("label"), Is.EqualTo(expectedGroupLabel));
+
+        var actualButtons = group.Elements(ns + "button").ToList();
+        Assert.That(actualButtons.Select(x => (string?)x.Attribute("id")).Distinct().Count(), Is.EqualTo(actualButtons.Count), "Button IDs must be unique.");
+        Assert.That(actualButtons, Has.Count.EqualTo(expectedButtons.Count));
+
+        foreach (var expectedButton in expectedButtons)
+        {
+            var button = actualButtons.SingleOrDefault(x => (string?)x.Attribute("id") == expectedButton.Id);
+            Assert.That(button, Is.Not.Null, $"Button '{expectedButton.Id}' was not found.");
+            Assert.That((string?)button!.Attribute("label"), Is.EqualTo(expectedButton.Label));
+            Assert.That((string?)button.Attribute("size"), Is.EqualTo(expectedButton.Size));
+            Assert.That((string?)button.Attribute("imageMso"), Is.EqualTo(expectedButton.ImageMso));
+            Assert.That((string?)button.Attribute("onAction"), Is.EqualTo(expectedButton.OnAction));
+        }
+    }
+
+    private static void AssertExcelRibbonButtons(string workbookPath, string tabLabel, string groupLabel, IReadOnlyDictionary<string, string> expectedCallbacks)
+    {
+        using var session = ExcelSession.Open(workbookPath);
+        using var automation = new UIA3Automation();
+        using var application = Application.Attach(session.ProcessId);
+
+        var window = application.GetMainWindow(automation, TimeSpan.FromSeconds(20));
+        Assert.That(window, Is.Not.Null, "Excel main window was not found.");
+        window!.Focus();
+        TryMaximize(window);
+
+        var tab = FindExcelRibbonElement(window, tabLabel, ControlType.TabItem, TimeSpan.FromSeconds(20));
+        Assert.That(tab, Is.Not.Null, $"Excel ribbon tab '{tabLabel}' was not found.");
+        tab!.Click();
+
+        var group = FindExcelRibbonElement(window, groupLabel, ControlType.Group, TimeSpan.FromSeconds(10)) ??
+            FindExcelRibbonElementByName(window, groupLabel, TimeSpan.FromSeconds(5));
+        Assert.That(group, Is.Not.Null, $"Excel ribbon group '{groupLabel}' was not found.");
+
+        foreach (var (buttonLabel, expectedMarker) in expectedCallbacks)
+        {
+            var button = FindExcelRibbonElement(window, buttonLabel, ControlType.Button, TimeSpan.FromSeconds(10));
+            Assert.That(button, Is.Not.Null, $"Excel ribbon button '{buttonLabel}' was not found.");
+
+            session.SetMarker(string.Empty);
+            button!.Click();
+            var marker = Retry.While(
+                () => session.Marker,
+                value => value != expectedMarker,
+                TimeSpan.FromSeconds(10),
+                TimeSpan.FromMilliseconds(250)).Result;
+
+            Assert.That(marker, Is.EqualTo(expectedMarker), $"Button '{buttonLabel}' did not run the expected VBA callback.");
+        }
+    }
+
+    private static AutomationElement? FindExcelRibbonElement(Window window, string name, ControlType controlType, TimeSpan timeout)
+    {
+        return Retry.WhileNull(
+            () => window.FindFirstDescendant(cf => cf.ByControlType(controlType).And(cf.ByName(name))),
+            timeout,
+            TimeSpan.FromMilliseconds(250)).Result;
+    }
+
+    private static AutomationElement? FindExcelRibbonElementByName(Window window, string name, TimeSpan timeout)
+    {
+        return Retry.WhileNull(
+            () => window.FindFirstDescendant(cf => cf.ByName(name)),
+            timeout,
+            TimeSpan.FromMilliseconds(250)).Result;
+    }
+
+    private static void TryMaximize(Window window)
+    {
+        try
+        {
+            window.Patterns.Window.Pattern.SetWindowVisualState(WindowVisualState.Maximized);
+        }
+        catch (InvalidOperationException)
+        {
+            // Some Excel startup states do not expose the window pattern immediately.
+        }
+    }
+
+    private static string ReadCustomPart(string workbookPath, XmlPart partType)
+    {
+        using var document = new OfficeDocument(workbookPath);
+        var part = document.RetrieveCustomPart(partType);
+        Assert.That(part, Is.Not.Null, $"Custom part '{partType}' was not found.");
+        return part!.ReadContent();
+    }
+
+    private static ProcessResult RunPowerShellTool(string repositoryRoot, string workbookPath, string definitionPath, string outputPath, bool forceInPlace = false)
+    {
+        var scriptPath = Path.Combine(repositoryRoot, "scripts", "Update-CustomUI14.ps1");
+        Assert.That(File.Exists(scriptPath), Is.True, $"PowerShell script was not found at '{scriptPath}'.");
+
+        var arguments = $"-NoProfile -ExecutionPolicy Bypass -File {Quote(scriptPath)} -WorkbookPath {Quote(workbookPath)} -DefinitionPath {Quote(definitionPath)}";
+        if (forceInPlace)
+        {
+            arguments += " -ForceInPlace";
+        }
+        else
+        {
+            arguments += $" -OutputPath {Quote(outputPath)}";
+        }
+
+        using var process = new Process();
+        process.StartInfo = new ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            Arguments = arguments,
+            WorkingDirectory = repositoryRoot,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+
+        process.Start();
+        var standardOutput = process.StandardOutput.ReadToEnd();
+        var standardError = process.StandardError.ReadToEnd();
+        Assert.That(process.WaitForExit(60000), Is.True, "PowerShell tool did not exit within 60 seconds.");
+
+        return new ProcessResult(process.ExitCode, standardOutput, standardError);
+    }
+
+    private static string Quote(string value)
+    {
+        return "\"" + value.Replace("\"", "\\\"", StringComparison.Ordinal) + "\"";
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(TestContext.CurrentContext.TestDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "OfficeRibbonXEditor.slnx")) &&
+                File.Exists(Path.Combine(directory.FullName, "scripts", "Update-CustomUI14.ps1")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        Assert.Fail("Could not locate the repository root.");
+        return string.Empty;
+    }
+
+    private static void PreserveWorkbookArtifact(string repositoryRoot, string sourceWorkbookPath)
+    {
+        var outputDirectory = Path.Combine(repositoryRoot, "tests", "UITests", "Output");
+        Directory.CreateDirectory(outputDirectory);
+
+        var artifactPath = Path.Combine(outputDirectory, "RibbonXUpdated.xlsm");
+        File.Copy(sourceWorkbookPath, artifactPath, overwrite: true);
+        TestContext.WriteLine($"Preserved workbook artifact: {artifactPath}");
+    }
+
+    private static bool IsExcelInstalled()
+    {
+        return Type.GetTypeFromProgID("Excel.Application") != null;
+    }
+
+    private static bool IsVbaProjectAccessTrusted()
+    {
+        using var securityKey = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Office\16.0\Excel\Security");
+        return Convert.ToInt32(securityKey?.GetValue("AccessVBOM") ?? 0) == 1;
+    }
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+
+    private sealed record ExpectedButton(string Id, string Label, string Size, string ImageMso, string OnAction);
+
+    private sealed record ProcessResult(int ExitCode, string StandardOutput, string StandardError)
+    {
+        public string AllOutput => StandardOutput + Environment.NewLine + StandardError;
+    }
+
+    private sealed class ExcelSession : IDisposable
+    {
+        private ExcelSession(object excel, int processId)
+        {
+            Excel = excel;
+            ProcessId = processId;
+        }
+
+        public object Excel { get; }
+
+        public object? Workbook { get; set; }
+
+        public int ProcessId { get; }
+
+        public string Marker
+        {
+            get
+            {
+                dynamic workbook = Workbook ?? throw new InvalidOperationException("Workbook is not open.");
+                return Convert.ToString(workbook.Worksheets[1].Range("A1").Value2) ?? string.Empty;
+            }
+        }
+
+        public static ExcelSession CreateVisible(bool visible)
+        {
+            var excelType = Type.GetTypeFromProgID("Excel.Application");
+            Assume.That(excelType, Is.Not.Null, "Excel.Application COM type was not found.");
+
+            var excel = Activator.CreateInstance(excelType!) ?? throw new InvalidOperationException("Could not start Excel.");
+            dynamic dynamicExcel = excel;
+            dynamicExcel.Visible = visible;
+            dynamicExcel.DisplayAlerts = false;
+            dynamicExcel.AutomationSecurity = MsoAutomationSecurityLow;
+
+            var hwnd = new IntPtr(Convert.ToInt32(dynamicExcel.Hwnd));
+            GetWindowThreadProcessId(hwnd, out var processId);
+            return new ExcelSession(excel, Convert.ToInt32(processId));
+        }
+
+        public static ExcelSession Open(string workbookPath)
+        {
+            var session = CreateVisible(visible: true);
+            dynamic excel = session.Excel;
+            excel.DisplayAlerts = false;
+            excel.AutomationSecurity = MsoAutomationSecurityLow;
+            session.Workbook = excel.Workbooks.Open(workbookPath);
+            excel.ActiveWindow.Activate();
+            return session;
+        }
+
+        public void SetMarker(string value)
+        {
+            dynamic workbook = Workbook ?? throw new InvalidOperationException("Workbook is not open.");
+            workbook.Worksheets[1].Range("A1").Value2 = value;
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (Workbook != null)
+                {
+                    dynamic workbook = Workbook;
+                    workbook.Close(SaveChanges: false);
+                }
+            }
+            catch (COMException)
+            {
+                // Excel may already be gone after a failing UI assertion.
+            }
+            finally
+            {
+                try
+                {
+                    dynamic excel = Excel;
+                    excel.Quit();
+                }
+                catch (COMException)
+                {
+                    // Nothing useful to do in test cleanup.
+                }
+
+                ReleaseComObject(Workbook);
+                ReleaseComObject(Excel);
+            }
+        }
+
+        private static void ReleaseComObject(object? value)
+        {
+            if (value != null && Marshal.IsComObject(value))
+            {
+                Marshal.FinalReleaseComObject(value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
﻿## What changed
- Added a PowerShell-only CustomUI14 updater for `.xlsm` files.
- Added sample definitions, usage docs, and an inspect helper.
- Added a Microsoft 365 imageMso catalog plus refresh script.
- Added Excel/FlaUI E2E coverage for creating, updating, and validating CustomUI14 ribbons.

## Why
This allows CustomUI14 ribbon buttons to be updated on target machines with Windows PowerShell only, without requiring Office RibbonX Editor or a .NET SDK at runtime.

## Validation
- `./.dotnet/dotnet.exe test tests/UITests/UITests.csproj --filter FullyQualifiedName~CustomUi14PowerShellE2ETests --logger "console;verbosity=minimal"`

Note: local test run passes with existing NuGet warnings for `System.Resources.Extensions` trimming and `log4net` GHSA-4f7c-pmjv-c25w.
